### PR TITLE
Fix read-only check.

### DIFF
--- a/nagios_cli/nagios.py
+++ b/nagios_cli/nagios.py
@@ -20,7 +20,7 @@ class Command(object):
         self.pipe.flush()
 
     def _read_only(self):
-        return bool(self.pipe)
+        return not(bool(self.pipe))
 
     read_only = property(_read_only)
 


### PR DESCRIPTION
The read-only check was backwards: it was returning True if the pipe had been opened succesfully in append-mode.  Invert it to get the proper sense.
