### PR TITLE
Centos 6 crashes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.pyo
 *.swp
 build
+nagios-cli.cfg

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.swp
 build
 nagios-cli.cfg
+.idea

--- a/nagios_cli/cli.py
+++ b/nagios_cli/cli.py
@@ -177,7 +177,10 @@ class CLI(object):
             if info:
                 # Function arguments count (minus self)
                 args = self.commands[name].run.func_code.co_argcount - 1
-                least = args - len(self.commands[name].run.func_defaults)
+                try:
+                    least = args - len(self.commands[name].run.func_defaults)
+                except TypeError:
+                    least = 0
                 # Given arguments count (minus self)
                 given = int(info.groupdict()['given']) - 1
                 if args == least:


### PR DESCRIPTION
Fixes the following errors I saw on CentOS 6 with Python 2.6

```
$ ./nagios-cli -c nagios-cli.cfg testhost01
Welcome to the nagios command line interface
nagios (host) testhost01> status jksldjfklsdf
/home/daniel/code/nagios-cli/nagios_cli/cli.py:175: DeprecationWarning: BaseException.message has been deprecated as of Python 2.6
  msg = e.message
/home/daniel/code/nagios-cli/nagios_cli/cli.py:176: DeprecationWarning: BaseException.message has been deprecated as of Python 2.6
  info = RE_RUN_GIVEN.search(e.message)
Traceback (most recent call last):
  File "./nagios-cli", line 87, in <module>
    sys.exit(run())
  File "./nagios-cli", line 84, in run
    return cli.run()
  File "/home/daniel/code/nagios-cli/nagios_cli/cli.py", line 273, in run
    self.dispatch(line)
  File "/home/daniel/code/nagios-cli/nagios_cli/cli.py", line 255, in dispatch
    if not self.command_run(cmnd, args):
  File "/home/daniel/code/nagios-cli/nagios_cli/cli.py", line 182, in command_run
    least = args - len(self.commands[name].run.func_defaults)
TypeError: object of type 'NoneType' has no len()
```
